### PR TITLE
_ClusterStreamMessage

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,14 @@ function Clusterstream(options, fn) {
       .pipe(split(DELIMITER))
       .pipe(Streamz(function(d) {
         d = JSON.parse(d);
-        if (d.error === true)
-          this.emit('error',d);
-        else
+        if (d._ClusterStreamMessage) {
+          if (d.error === true)
+            this.emit('error',d);
+          else if (d.end === true) {
+            worker.disconnect();
+            this.end();
+          }
+        } else
           return d;
       },{highWaterMark}))
       .on('end', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clusterstream",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Piping streams across a cluster of Workers",
   "keywords": [
     "stream",

--- a/worker.js
+++ b/worker.js
@@ -7,7 +7,16 @@ const highWaterMark = 1;
 // within `new Function(..)`
 global.require = require;
 global.console.log = console.error;
-const out = Streamz(null,{highWaterMark});
+const out = Streamz(null,{
+  highWaterMark,
+  flush: function(cb) {
+    this.push({
+      _ClusterStreamMessage: true,
+      end: true
+    });
+    cb();
+  }
+});
 
 let fn;
 
@@ -47,6 +56,7 @@ const worker = process.stdin
 out
   .on('error',e => {
     e = {
+      _ClusterStreamMessage: true,
       message: e.message || e,
       stack: e.stack,
       error: true


### PR DESCRIPTION
worker.stdout.end is not to be trusted completely.  We define internal clusterstream messages as json packets with `_ClusterStreamMessage:  true` and close by sending `end: true`